### PR TITLE
fix: Run vitest eslint rules only in unit test files

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,16 @@
 export const ERROR = 'error';
-
 export const OFF = 'off';
 
-export const testFiles = ['**/*.{spec,test,e2e,cy}.{js,jsx,ts,tsx}'];
+const jsFileExtensions = ['js', 'jsx', 'mjs', /*   */ 'cjs' /*   */];
+const tsFileExtensions = ['ts', 'tsx', 'mts', 'mtsx', 'cts', 'ctsx'];
+const allFileExtensions = [...jsFileExtensions, ...tsFileExtensions];
 
-export const typescriptFiles = ['**/*.{ts,tsx,mts,mtsx,cts,ctsx}'];
+export const unitTestFiles = [
+  `**/*.{spec,test}.{${allFileExtensions.join(',')}}`
+];
+export const cypressTestFiles = [
+  `**/*.{cy,e2e}.{${allFileExtensions.join(',')}}`
+];
+export const allTestFiles = [...unitTestFiles, ...cypressTestFiles];
+
+export const typescriptFiles = [`**/*.{${tsFileExtensions.join(',')}}`];

--- a/src/cssModules.js
+++ b/src/cssModules.js
@@ -2,7 +2,7 @@
 
 // @ts-expect-error -- False positive
 import cssModules from 'eslint-plugin-css-modules';
-import { ERROR, OFF, testFiles } from './config.js';
+import { ERROR, OFF, allTestFiles } from './config.js';
 
 /**
  * @type {Array<import('eslint').Linter.Config>}
@@ -18,7 +18,7 @@ export default [
     }
   },
   {
-    files: testFiles,
+    files: allTestFiles,
     rules: {
       'css-modules/no-unused-class': OFF
     }

--- a/src/cypress.js
+++ b/src/cypress.js
@@ -1,13 +1,13 @@
 // @ts-check
 
-import { ERROR, testFiles } from './config.js';
+import { ERROR, cypressTestFiles } from './config.js';
 
 /**
  * @type {Array<import('eslint').Linter.Config>}
  */
 export default [
   {
-    files: testFiles,
+    files: cypressTestFiles,
     rules: {
       'no-restricted-properties': [
         ERROR,

--- a/src/jest.js
+++ b/src/jest.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import jestPlugin from 'eslint-plugin-jest';
-import { ERROR, testFiles } from './config.js';
+import { ERROR, unitTestFiles } from './config.js';
 
 /**
  * @type {Array<import('eslint').Linter.Config>}
@@ -11,7 +11,7 @@ export default [
     plugins: {
       jest: jestPlugin
     },
-    files: testFiles,
+    files: unitTestFiles,
     ...jestPlugin.configs['flat/recommended'],
     rules: {
       ...jestPlugin.configs['flat/recommended'],

--- a/src/vitest.js
+++ b/src/vitest.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import vitestPlugin from '@vitest/eslint-plugin';
-import { ERROR, testFiles } from './config.js';
+import { ERROR, unitTestFiles } from './config.js';
 
 /**
  * @type {Array<import('eslint').Linter.Config>}
@@ -11,7 +11,7 @@ export default [
     plugins: {
       vitest: vitestPlugin
     },
-    files: testFiles,
+    files: unitTestFiles,
     rules: {
       ...vitestPlugin.configs.recommended.rules,
       'vitest/consistent-test-it': [


### PR DESCRIPTION
Fixes #6 