### PR TITLE
feat: Stricter settings for imports and exports

### DIFF
--- a/src/javascript.js
+++ b/src/javascript.js
@@ -42,7 +42,7 @@ export default [
       'import/namespace': ERROR,
       'import/default': ERROR,
       'import/export': ERROR,
-      'import/no-duplicates': ERROR,
+      'import/no-duplicates': [ERROR, { 'prefer-inline': true }],
       'import/newline-after-import': ERROR,
       'import/no-unresolved': [ERROR, { commonjs: true }],
       'import/no-extraneous-dependencies': ERROR,

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -82,10 +82,6 @@ export default [
       // Too restrictive
       '@typescript-eslint/no-empty-object-type': OFF,
       '@typescript-eslint/consistent-type-definitions': [ERROR, 'type'],
-      '@typescript-eslint/consistent-type-exports': [
-        ERROR,
-        { fixMixedExportsWithInlineTypeSpecifier: true }
-      ],
       // Prevent type parameter names like `TValue`, `T`, `T1`
       '@typescript-eslint/naming-convention': [
         ERROR,

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -57,6 +57,7 @@ export default [
       '@typescript-eslint/await-thenable': ERROR,
       '@typescript-eslint/method-signature-style': [ERROR, 'property'],
       '@typescript-eslint/no-for-in-array': ERROR,
+      '@typescript-eslint/no-import-type-side-effects': ERROR,
       '@typescript-eslint/no-misused-promises': [
         ERROR,
         { checksVoidReturn: { attributes: false } }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
Addresses https://github.com/tools-aoeur/eslint-config/issues/9

**Changes**

- Set `verbatimModuleSyntax` to `true`
- Remove redundant `consistent-type-exports` rule
- Enable `no-import-type-side-effects` rule
- Set `prefer-inline` to `true` for `no-duplicates`