### PR TITLE
fix: Apply `parserOptions` unconditionally in typescript preset

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -16,7 +16,13 @@ export default [
   ...typescriptEslint.configs.recommended,
   ...typescriptEslint.configs.stylisticTypeChecked,
   importPlugin.configs.typescript,
-
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true
+      }
+    }
+  },
   {
     // Only apply TypeScript rules to TypeScript files to avoid
     // causing issues in regular JavaScript files. See also:
@@ -24,11 +30,6 @@ export default [
     files: typescriptFiles,
     settings: {
       'import/resolver': 'typescript'
-    },
-    languageOptions: {
-      parserOptions: {
-        projectService: true
-      }
     },
     rules: {
       // The TypeScript compiler takes care of this


### PR DESCRIPTION
I finally found the culprit that we previously discussed in https://github.com/tools-aoeur/eslint-config/pull/7#discussion_r1827883240.

TS-only rules fail when being run on JavaScript files. The error I previously saw in Horusnome was caused by a JavaScript file in `.` (probably `eslint.config.mjs`), therefore the fix was to run ESLint only on `src`. Now, in the CL I ran into the error again, but was able to isolate it to linting a JavaScript file within `src`.

The fix is to set parser options always when the `typescript` preset is used.